### PR TITLE
Add Outernet Space Agency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Here's a list of guilds already in the works:
 
 **💡 Debates & Trivia ([#outernet-debates-and-trivia](https://app.slack.com/client/T0266FRGM/C058SH88N5R/))**: Want to debate the best editor? Have fun answering questions about Hack Club and miscellanea? Join us! We'll be having a few casual events and a tournament.
 
+**🌌 Outernet Space Agency ([#outernet-space-agency](https://hackclub.slack.com/archives/C059DHPQBUG))**: The Outernet Space Agency is a fully-functional* space agency that will be operating throughout Outernet! We'll build rockets, track the stars and satellites, and participate in much more space nerdiness!
+
 
 You're welcome to get involved with one of them on Slack or start your own guild with friends!
 


### PR DESCRIPTION
# Outernet Space Agency
The Outernet Space Agency is a fully-functional* space agency that will be operating throughout Outernet! We'll build rockets, track the stars and satellites, and participate in much more space nerdiness!

## Guild Members
@polypixeldev 
@Arpan-206
@CaitPrough
@Leo32345
@alexdevz